### PR TITLE
Updated BinaryInstall documentation to use new Installer

### DIFF
--- a/BinaryInstall.md
+++ b/BinaryInstall.md
@@ -202,6 +202,12 @@ bash lisk.sh start
 bash lisk.sh restart
 ```
 
+To reload config.json changes:
+
+```text
+bash lisk.sh reload
+```
+
 To check the status of lisk:
 
 ```text

--- a/BinaryInstall.md
+++ b/BinaryInstall.md
@@ -138,7 +138,7 @@ bash lisk.sh start
 
 Then, open the Lisk web client and wait for the blockchain to load. Once the blockchain has loaded, navigate to "Forging" section, and verify that **Forging (Enabled)** appears in the top left corner.
 
-## 5. Enable Secure Sockets Layer (SSL)
+## 4. Enable Secure Sockets Layer (SSL)
 
 **NOTE:** To complete this step you require a signed certificate (from a CA) and a public and private key pair.
 
@@ -170,10 +170,14 @@ Arrow down until you find the following section:
 
 After you are done, save changes and exit. Hit: `Ctrl+ X` Then: `Y`
 
-**NOTE:** If SSL Port configured above (ssl > options > port) is within well known ports range (below 1024), you must start Lisk with admin rights:
+**NOTE:** If SSL Port configured above (ssl > options > port) is within well known ports range (below 1024), you must alter the port specified with setcap.
 
 ```text
-sudo bash lisk.sh start
+sudo setcap cap_net_bind_service=+ep bin/node
+```
+
+```text
+bash lisk.sh start
 ```
 
 If the port is above 1023, you can start Lisk normally:
@@ -184,7 +188,7 @@ bash lisk.sh start
 
 Open the web client. You should now have an SSL enabled connection.
 
-## 6. Available Commands
+## 5. Available Commands
 
 Listed below, are the available commands which can be used to manage your Lisk node.
 

--- a/BinaryInstall.md
+++ b/BinaryInstall.md
@@ -170,19 +170,13 @@ Arrow down until you find the following section:
 
 After you are done, save changes and exit. Hit: `Ctrl+ X` Then: `Y`
 
-**NOTE:** If SSL Port configured above (ssl > options > port) is within well known ports range (below 1024), you must alter the port specified with setcap.
+**NOTE:** If SSL Port configured above (ssl > options > port) is within well known ports range (below 1024), you must alter the port specified with setcap or change it to be outside of that range.
 
 ```text
 sudo setcap cap_net_bind_service=+ep bin/node
 ```
 
-Then you may start Lisk
-
-```text
-bash lisk.sh start
-```
-
-If the port is above 1023, you can start Lisk normally:
+Once this is done, or the port specified is above 1024, you may start Lisk
 
 ```text
 bash lisk.sh start

--- a/BinaryInstall.md
+++ b/BinaryInstall.md
@@ -66,6 +66,7 @@ Follow the download instructions to install Lisk for your selected platform.
   ```
 
 5. Accesing Lisk
+
  To access the Lisk web client, open: [http://localhost:8000/](http://localhost:8000/) if on the mainnet (once Lisk is launched) or [http://localhost:7000/](http://localhost:7000/) if on a testnet, replacing **localhost** with your public IP address if you have one.
 
  The Lisk web client should launch successfully.

--- a/BinaryInstall.md
+++ b/BinaryInstall.md
@@ -176,6 +176,8 @@ After you are done, save changes and exit. Hit: `Ctrl+ X` Then: `Y`
 sudo setcap cap_net_bind_service=+ep bin/node
 ```
 
+Then you may start Lisk
+
 ```text
 bash lisk.sh start
 ```

--- a/BinaryInstall.md
+++ b/BinaryInstall.md
@@ -65,7 +65,7 @@ Follow the download instructions to install Lisk for your selected platform.
   echo "source $(pwd)/env.sh" >> ~/.bash_profile
   ```
 
-5. Accesing Lisk
+5. Accessing Lisk
 
  To access the Lisk web client, open: [http://localhost:8000/](http://localhost:8000/) if on the mainnet (once Lisk is launched) or [http://localhost:7000/](http://localhost:7000/) if on a testnet, replacing **localhost** with your public IP address if you have one.
 

--- a/BinaryInstall.md
+++ b/BinaryInstall.md
@@ -4,6 +4,8 @@ This tutorial describes how to install the Lisk using pre-built binary packages.
 
 To complete the installation, you will need to have `bash`, `curl`, `wget` and `tar` installed. The majority of operating systems have these installed by default, if not, please install them before continuing.
 
+**NOTE:** With the release of **0.2.1**, PostgreSQL no longer needs to be installed separately. If you have installed it as part of a previous Lisk release, please stop it before continuing, e.g. on Ubuntu Linux do the following: **sudo service postgresql stop**.
+
 ## 1. Select Platform
 
 The following operating systems and architectures are supported:
@@ -27,28 +29,28 @@ If your architecture is not supported yet, you can try building your own package
 
 ## 2. Download Lisk
 
-Follow the relevant download instructions for your selected platform as listed below.
+Follow the download instructions to install Lisk for your selected platform.
 
-### Linux (x86_64)
+### All Platforms
 
-1. Choose a network and download the appropriate archive:
+1. Choose a network and download the appropriate install script:
 
   **Testnet** (_for development purposes_):
 
   ```text
-  wget https://downloads.lisk.io/lisk/test/lisk-Linux-x86_64.tar.gz
+  wget https://downloads.lisk.io/lisk/test/installLisk.sh
   ```
 
-2. Decompress the archive:
+2. Execute the install script. This will download and install Lisk, configuring the environment for use.
 
   ```text
-  tar -zxvf lisk-Linux-x86_64.tar.gz
+  bash installLisk.sh install
   ```
 
 3. Change directory:
 
   ```text
-  cd lisk-Linux-x86_64
+  cd lisk
   ```
 
 4. Configure environment _(optional, for dapps development)_:
@@ -63,216 +65,16 @@ Follow the relevant download instructions for your selected platform as listed b
   echo "source $(pwd)/env.sh" >> ~/.bash_profile
   ```
 
-5. Proceed with the next step in this tutorial to [Start Lisk](#3-start-lisk).
+5. Accesing Lisk
+ To access the Lisk web client, open: [http://localhost:8000/](http://localhost:8000/) if on the mainnet (once Lisk is launched) or [http://localhost:7000/](http://localhost:7000/) if on a testnet, replacing **localhost** with your public IP address if you have one.
 
-### Linux (i686)
+ The Lisk web client should launch successfully.
+ 
+6. Proceed with the next step in this tutorial to [Enable Forging](#3-enable-forging).
 
-1. Choose a network and download the appropriate archive:
 
-  **Testnet** (_for development purposes_):
 
-  ```text
-  wget https://downloads.lisk.io/lisk/test/lisk-Linux-i686.tar.gz
-  ```
-
-2. Decompress the archive:
-
-  ```text
-  tar -zxvf lisk-Linux-i686.tar.gz
-  ```
-
-3. Change directory:
-
-  ```text
-  cd lisk-Linux-i686
-  ```
-
-4. Configure environment _(optional, for dapps development)_:
-
-  ```text
-  source env.sh
-  ```
-
-  Add this to your `.bash_profile` to make this change permanent:
-
-  ```text
-  echo "source $(pwd)/env.sh" >> ~/.bash_profile
-  ```
-
-5. Proceed with the next step in this tutorial to [Start Lisk](#3-start-lisk).
-
-### Linux (armv6l)
-
-Tested devices: [Raspberry Pi 1 Model B+](https://www.raspberrypi.org/products/model-b-plus/) / [Raspberry Pi Zero](https://www.raspberrypi.org/products/pi-zero/)
-
-1. Choose a network and download the appropriate archive:
-
-  **Testnet** (_for development purposes_):
-
-  ```text
-  wget https://downloads.lisk.io/lisk/test/lisk-Linux-armv6l.tar.gz
-  ```
-
-2. Decompress the archive:
-
-  ```text
-  tar -zxvf lisk-Linux-armv6l.tar.gz
-  ```
-
-3. Change directory:
-
-  ```text
-  cd lisk-Linux-armv6l
-  ```
-
-4. Configure environment _(optional, for dapps development)_:
-
-  ```text
-  source env.sh
-  ```
-
-  Add this to your `.bash_profile` to make this change permanent:
-
-  ```text
-  echo "source $(pwd)/env.sh" >> ~/.bash_profile
-  ```
-
-5. Proceed with the next step in this tutorial to [Start Lisk](#3-start-lisk).
-
-### Linux (armv7l)
-
-Tested devices: [Raspberry Pi 2 Model B](https://www.raspberrypi.org/products/raspberry-pi-2-model-b/) / [C.H.I.P.](http://getchip.com/)
-
-1. Choose a network and download the appropriate archive:
-
-  **Testnet** (_for development purposes_):
-
-  ```text
-  wget https://downloads.lisk.io/lisk/test/lisk-Linux-armv7l.tar.gz
-  ```
-
-2. Decompress the archive:
-
-  ```text
-  tar -zxvf lisk-Linux-armv7l.tar.gz
-  ```
-
-3. Change directory:
-
-  ```text
-  cd lisk-Linux-armv7l
-  ```
-
-4. Configure environment _(optional, for dapps development)_:
-
-  ```text
-  source env.sh
-  ```
-
-  Add this to your `.bash_profile` to make this change permanent:
-
-  ```text
-  echo "source $(pwd)/env.sh" >> ~/.bash_profile
-  ```
-
-5. Proceed with the next step in this tutorial to [Start Lisk](#3-start-lisk).
-
-### Darwin (x86_64)
-
-1. Choose a network and download the appropriate archive:
-
-  **Testnet** (_for development purposes_):
-
-  ```text
-  wget https://downloads.lisk.io/lisk/test/lisk-Darwin-x86_64.tar.gz
-  ```
-
-2. Decompress the archive:
-
-  ```text
-  tar -zxvf lisk-Darwin-x86_64.tar.gz
-  ```
-
-3. Change directory:
-
-  ```text
-  cd lisk-Darwin-x86_64
-  ```
-
-4. Configure environment _(optional, for dapps development)_:
-
-  ```text
-  source env.sh
-  ```
-
-  Add this to your `.bash_profile` to make this change permanent:
-
-  ```text
-  echo "source $(pwd)/env.sh" >> ~/.bash_profile
-  ```
-
-5. Proceed with the next step in this tutorial to [Start Lisk](#3-start-lisk).
-
-### FreeBSD (amd64)
-
-1. Choose a network and download the appropriate archive:
-
-  **Testnet** (_for development purposes_):
-
-  ```text
-  wget https://downloads.lisk.io/lisk/test/lisk-FreeBSD-amd64.tar.gz
-  ```
-
-2. Decompress the archive:
-
-  ```text
-  tar -zxvf lisk-FreeBSD-amd64.tar.gz
-  ```
-
-3. Change directory:
-
-  ```text
-  cd lisk-FreeBSD-amd64
-  ```
-
-4. Configure environment _(optional, for dapps development)_:
-
-  ```text
-  source env.sh
-  ```
-
-  Add this to your `.bash_profile` to make this change permanent:
-
-  ```text
-  echo "source $(pwd)/env.sh" >> ~/.bash_profile
-  ```
-
-5. Proceed with the next step in this tutorial to [Start Lisk](#3-start-lisk).
-
-## 3. Start Lisk
-
-**NOTE:** With the release of **0.2.1**, PostgreSQL no longer needs to be installed separately. If you have installed it as part of a previous Lisk release, please stop it before continuing, e.g. on Ubuntu Linux do the following: **sudo service postgresql stop**.
-
-To start lisk for the first time, simply run the following command from within the current directory:
-
-```text
-bash lisk.sh coldstart
-```
-
-On the first invocation of this command: Lisk will configure itself to automatically start when booting your machine, and a snapshot of the blockchain will be downloaded for your convenience.
-
-The `bash lisk.sh coldstart` command only needs to be executed **once**. To manually stop or start your lisk node, please use the following commands:
-
-```text
-bash lisk.sh stop
-bash lisk.sh start
-```
-
-To access the Lisk web client, open: [http://localhost:8000/](http://localhost:8000/) if on the mainnet (once Lisk is launched) or [http://localhost:7000/](http://localhost:7000/) if on a testnet, replacing **localhost** with your public IP address if you have one.
-
-The Lisk web client should launch successfully.
-
-## 4. Enable Forging
+## 3. Enable Forging
 
 If you are running your node from a local machine, you can enable forging through the web client, without further interruption. **NOTE:** Should the Lisk node or machine need to be restarted, you will need to re-enable forging again.
 


### PR DESCRIPTION
The next release will have an installer for installing all dependencies other than bash and take care of the installation of NTP or enabling it on any system that has it installed but not running.

The installer will also handle the starting of Lisk for the first time so coldstart instructions are no longer needed.