### PR TITLE
[LISKDOCS-24]Update typography for mobile-view

### DIFF
--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -1,31 +1,31 @@
 h1 {
-    font-size: 60px;
+    font-size: 3.75rem;
     font-family: 'InstrumentSans-SemiBold';
 }
 
 h2 {
-    font-size: 48px;
+    font-size: 3rem;
     font-family: 'InstrumentSans-SemiBold';
 }
 
 h3 {
-    font-size: 40px;
+    font-size: 2.5rem;
     font-family: 'InstrumentSans-SemiBold';
 }
 
 h4 {
-    font-size: 32px;
+    font-size: 2rem;
     font-family: 'InstrumentSans-SemiBold';
 }
 
 h5 {
-    font-size: 24px;
+    font-size: 1.5rem;
     font-family: 'InstrumentSans';
 }
 
 h6 {
+    font-size: 1.125rem;
     font-family: 'InstrumentSans';
-    font-size: 16px;
 }
 
 .line-space-subtile {
@@ -40,4 +40,46 @@ h6 {
     padding-top: 5%;
     height: 54%;
     margin-bottom: 35%;
+}
+
+@media (max-width: 576px) {
+    .markdown h1:first-child {
+        --ifm-h1-font-size: 2.5rem
+    }
+
+    .markdown>h2 {
+        --ifm-h2-font-size: 2.25rem
+    }
+
+    .markdown>h3 {
+        --ifm-h3-font-size: 2rem
+    }
+
+    .hero__title {
+        font-size: var(--ifm-h1-font-size);
+    }
+
+    h1 {
+        font-size: 2.5rem;
+    }
+
+    h2 {
+        font-size: 2.25rem;
+    }
+
+    h3 {
+        font-size: 2rem;
+    }
+
+    h4 {
+        font-size: 1.75rem;
+    }
+
+    h5 {
+        font-size: 1.5rem;
+    }
+
+    h6 {
+        font-size: 1.25rem;
+    }
 }


### PR DESCRIPTION
### What was the problem?

This PR resolves [LISKDOCS-24]

### How was it tested?

The updated font size was tested on the following screens:
<img width="198" alt="image" src="https://github.com/user-attachments/assets/0ec29aa9-7d04-4e56-bdc4-4c0d576a2b60">


[LISKDOCS-24]: https://onchaincollective.atlassian.net/browse/LISKDOCS-24?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ