### PR TITLE
[LISKDOCS-34] Resolve "Page Not Found"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,7 +24,7 @@ const config = {
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   /* organizationName: 'LiskHQ', // Usually your GitHub org/user name.
-  projectName: 'lisk-documentation', // Usually your repo name. 
+  projectName: 'lisk-documentation', // Usually your repo name.
   trailingSlash: false, */
 
   onBrokenLinks: 'throw',
@@ -107,11 +107,11 @@ const config = {
         },
         items: [
           /*
-            TODO: Uncomment when all localozed pages are translated*/
+            TODO: Uncomment when all localozed pages are translated
           {
             type: 'localeDropdown',
             position: 'right',
-          },
+          }, */
           {
             type: 'doc',
             position: 'left',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,7 +24,7 @@ const config = {
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   /* organizationName: 'LiskHQ', // Usually your GitHub org/user name.
-  projectName: 'lisk-documentation', // Usually your repo name.
+  projectName: 'lisk-documentation', // Usually your repo name. 
   trailingSlash: false, */
 
   onBrokenLinks: 'throw',
@@ -37,6 +37,13 @@ const config = {
     defaultLocale: 'en',
     locales: ['en', 'ind'],
     localeConfigs: {
+      en: {
+        label: 'English',
+        direction: 'ltr',
+        htmlLang: 'en-US',
+        calendar: 'gregory',
+        path: 'en',
+      },
       ind: {
         label: 'Indonesian',
       },
@@ -99,12 +106,12 @@ const config = {
           srcDark: '/img/lisk-docs-dark.svg',
         },
         items: [
-          /*{
-            TODO: Uncomment when all localozed pages are translated
-          /* {
+          /*
+            TODO: Uncomment when all localozed pages are translated*/
+          {
             type: 'localeDropdown',
             position: 'right',
-          }, */
+          },
           {
             type: 'doc',
             position: 'left',


### PR DESCRIPTION
### What was the problem?

This PR resolves [LISKDOCS-34]

### How was it tested?

- There is a 'Page Not Found' behavior on docs.lisk.com, which causes the crawler to fail because it also fails to identify our pages during its crawl.

- Updating the configuration about the `locale` eliminates the error.

[LISKDOCS-34]: https://onchaincollective.atlassian.net/browse/LISKDOCS-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ