### PR TITLE
docs: fix typo Update intro.mdx

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -10,7 +10,7 @@ keywords:
     scalable,
     secured by Ethereum,
     Optimism's L2 rollup,
-    Optimism's Super chain,
+    Optimism's Superchain,
     interoperable,
     great user experience,
     shared liquidity,


### PR DESCRIPTION
### What was the problem?

The term "Superchain" is written without a space.
