### PR TITLE
Fix spelling issues in documentation

### DIFF
--- a/docs/docs-user/exchanges.md
+++ b/docs/docs-user/exchanges.md
@@ -34,7 +34,7 @@ Lisk (LSK) is available for trading on various <!-- decentralized and centralize
 | **OKX**                  | 🟢 Lisk            | [LSK/USDT](https://www.okx.com/fr/trade-spot/lsk-usdt)        |
 | **Upbit** (Korea)        | 🟢 Lisk            | [LSK/KRW](https://upbit.com/exchange?code=CRIX.UPBIT.KRW-LSK) |
 | **XT.com**               | 🟢 Lisk            | [LSK/USDT](https://www.xt.com/en/trade/lsk_usdt)<br />[LSK/BTC](https://www.xt.com/en/trade/lsk_btc) |
-| **HTX** (formerly Houbi) | 🟣 Ethereum <br/>(Lisk support coming soon) | [LSK/USDT](https://www.htx.com.jm/trade/lsk_usdt/)            |
+| **HTX** (formerly Huobi) | 🟣 Ethereum <br/>(Lisk support coming soon) | [LSK/USDT](https://www.htx.com.jm/trade/lsk_usdt/)            |
 | **Binance**              | 🟡 Ethereum        | [LSK/USDT](https://www.binance.com/en/trade/LSK_USDT?type=spot)<br />[LSK/BTC](https://www.binance.com/en/trade/LSK_BTC?type=spot)<br />[LSK/ETH](https://www.binance.com/en/trade/LSK_ETH?type=spot) |
 | **BinanceUS**            | 🟡 Ethereum        | [LSK/USDT](https://www.binance.us/spot-trade/lsk_usdt)        |
 | **Bitflyer**             | 🟡 Ethereum        | [LSK/EUR](https://bitflyer.com/fr-eu/lisk-chart)              |

--- a/docs/docs-user/wallets.md
+++ b/docs/docs-user/wallets.md
@@ -120,7 +120,7 @@ DeFi apps can be accessed and user funds can be put to work from inside the Safe
 Main features:
 - **Non-custodial**
 - **EVM wallet**
-- **Multisig**: Mutisignature for individuals and teams of any size.
+- **Multisig**: Multisignature for individuals and teams of any size.
 - **Web and Mobile versions**
 - **Token Support**: ETH, ERC 20 (including LSK), and ERC 721/1155 (NFTs) support.
 


### PR DESCRIPTION
### What was the problem?

I noticed a couple of small spelling errors in the documentation that I’ve gone ahead and corrected:

1. In the `docs/docs-user/exchanges.md` file, "Houbi" has been corrected to "Huobi".
2. In the `docs/docs-user/wallets.md` file, "Mutisignature" has been corrected to "Multisignature" in the "Safe" section.

Thanks for Lisk!